### PR TITLE
Configure update strategy

### DIFF
--- a/helm/alert-logic/templates/daemonset.yaml
+++ b/helm/alert-logic/templates/daemonset.yaml
@@ -11,6 +11,8 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.service.name }} 
+  updateStrategy:
+    type: "RollingUpdate"
   template:
     metadata:
       labels:


### PR DESCRIPTION
- the default rolling update strategy doesn't automatically update the daemon set, more details [here](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy) - configured it so it automatically updates whenever we release a new version
  