### PR TITLE
Alert logic container spec update

### DIFF
--- a/helm/alert-logic/templates/daemonset.yaml
+++ b/helm/alert-logic/templates/daemonset.yaml
@@ -21,8 +21,6 @@ spec:
     spec:
       tolerations:
       - operator: "Exists"
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       volumes:
       - name: docker-sock-volume
         hostPath:

--- a/helm/alert-logic/templates/daemonset.yaml
+++ b/helm/alert-logic/templates/daemonset.yaml
@@ -35,11 +35,7 @@ spec:
         image: {{ .Values.image.repository }} 
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - NET_ADMIN
-            - NET_BIND_SERVICE
+          privileged: true
         volumeMounts:
         - mountPath: /var/run/docker.sock
           name: docker-sock-volume

--- a/helm/alert-logic/templates/daemonset.yaml
+++ b/helm/alert-logic/templates/daemonset.yaml
@@ -20,7 +20,8 @@ spec:
         visualize: "true"
     spec:
       tolerations:
-      - operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       volumes:
       - name: docker-sock-volume
         hostPath:

--- a/helm/alert-logic/templates/daemonset.yaml
+++ b/helm/alert-logic/templates/daemonset.yaml
@@ -20,6 +20,7 @@ spec:
         visualize: "true"
     spec:
       tolerations:
+      - operator: "Exists"
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       volumes:

--- a/helm/alert-logic/templates/daemonset.yaml
+++ b/helm/alert-logic/templates/daemonset.yaml
@@ -45,11 +45,5 @@ spec:
           name: docker-sock-volume
         - mountPath: /host/proc
           name: docker-proc-volume
-        env:
-          - name: KEY
-            valueFrom:
-              secretKeyRef:
-                name: global-secrets
-                key: alertlogic.registration-key
         resources:
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
Updating the spec of the Alert Logic agent container to be more like the recommended spec from the official repo. https://github.com/alertlogic/al-agent-container/blob/master/kubernetes/al-agent-container.yaml

Not all instances in the k8s are registering successfully and the hope is this updated will resolve this issue. If it doesn't, I'll need to go back to the drawing board with Alert Logic to find out what is happening.

This PR includes JPD's change from https://github.com/Financial-Times/content-alertlogic-helm-config/pull/7

The 3 updates are:
1. The registration key is not needed when in an AWS account as Alert Logic can auto register based on the account the instance is in.
2. The current securityContext used was previously in the official repo but has been changed since.
3. I'm not sure where the current tolerations came from but I have updated them to the official one.

Please review and, if acceptable, deploy to test and I can see if this has resolved the issue we saw.